### PR TITLE
fix example

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,8 +73,8 @@ export default function App() {
   }
 
   function onChange(blobObject: ReactVisualAudioRecorderBlobObject) {
-    if (!blobObject) return;
-    setUrl(blobObject.blobURL);
+    if (!blobObject.blob) return;
+    setUrl(URL.createObjectURL(blobObject.blob));
   }
 
   function reset() {


### PR DESCRIPTION
the latest version from npm has blob instead of bloburl on the ReactVisualAudioRecorderBlobObject.

This change is necessary to get the example working.